### PR TITLE
Fix SIGBUS Crash by Disabling mmap-backed Packfile Access

### DIFF
--- a/git.go
+++ b/git.go
@@ -141,6 +141,16 @@ func initLibGit2() {
 	remotePointers = newRemotePointerList()
 
 	C.git_libgit2_init()
+
+	// Mitigation for SIGBUS crashes during packfile access:
+	// avoid using mmap-backed pack windows by default. This forces libgit2
+	// to use read-based I/O so that concurrent truncation or replacement of
+	// packfiles results in regular I/O errors instead of kernel SIGBUS.
+	// Applications that want mmap performance can override these at runtime
+	// via SetMwindowSize/SetMwindowMappedLimit.
+	_ = SetMwindowSize(0)
+	_ = SetMwindowMappedLimit(0)
+
 	features := Features()
 
 	// Due to the multithreaded nature of Go and its interaction with


### PR DESCRIPTION
This pull request addresses the SIGBUS crash issue encountered during packfile access in the libgit2 library, which is impacting project stability. By modifying `initLibGit2()` in `git.go`, we avoid using mmap-backed pack windows by default, ensuring that libgit2 relies on read-based I/O instead. This change mitigates the risk of concurrent truncation or replacement of packfiles, which previously led to irregular I/O errors and crashes. Users who require mmap performance can still adjust this behavior at runtime using `SetMwindowSize` and `SetMwindowMappedLimit`. This fix should enhance the reliability of the codebase when handling Git operations.

---

> This pull request was co-created with Cosine Genie

Original Task: [git2go/jf1b05bbywzf](https://cosine.wtf/cosine-stg/git2go/task/jf1b05bbywzf)
Author: John Ingram
